### PR TITLE
[Do not merge] Build project with K2 compiler

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="Kotlin2JvmCompilerArguments">
+    <option name="jvmTarget" value="1.8" />
+  </component>
+  <component name="KotlinCommonCompilerArguments">
+    <option name="apiVersion" value="2.0" />
+    <option name="languageVersion" value="2.0" />
+  </component>
   <component name="KotlinJpsPluginSettings">
     <option name="version" value="1.9.22" />
   </component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,17 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
+
+# Use latest lint alpha for best available K2 support
+# https://googlesamples.github.io/android-custom-lint-rules/usage/newer-lint.md.html
+android.experimental.lint.version=8.4.0-alpha07
+
+# Use K2 compiler
+kotlin.experimental.tryK2=true
+
+# Run lint on K2
+android.lint.useK2Uast=true
+
 # Fill these details for Maven publish and then run the command:
 # ./gradlew publishAndReleaseToMavenCentral --no-configuration-cache
 # The rest of the setup is there in build.gradle of jetlime module


### PR DESCRIPTION
This PR demonstrates trying the [K2 compiler](https://kotlinlang.org/docs/whatsnew19.html#new-kotlin-k2-compiler-updates) in an Android project.

It should be continuously rebased onto main to ensure that everything still works on the K2 compiler, but only merged once K2 is stable.