### PR TITLE
feat: native pagination support (JetLimePaginatedColumn / JetLimePaginatedRow)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,21 @@ JetLimePaginatedColumn(
 }
 ```
 
-A default centered progress indicator is shown while `isLoading` is `true`; override it with the
-`loadingContent` parameter.
+A default centered progress indicator is shown while `isLoading` is `true`. Customize it by passing
+your own composable to `loadingContent`, or hide it entirely by passing `loadingContent = null` (no
+footer is added in that case):
+
+```kotlin
+JetLimePaginatedColumn(
+  itemsList = ItemsList(items),
+  isLoading = isLoading,
+  hasMoreItems = hasMore,
+  onLoadMore = { /* ... */ },
+  loadingContent = null, // or a custom composable, e.g. { MyLoader() }
+) { index, item, position ->
+  // Content here
+}
+```
 
 ### 🎛️ Customize `JetLimeColumn` Style
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - RTL layout support for JetLimeRow and JetLimeExtendedEvent (mirrors timelines and keeps content visible in right-to-left layouts)
 - Dashed/gradient/solid lines via Brush + PathEffect
 - Extended events with dual content slots (left/right), icons, and animations
+- Built-in pagination / infinite scroll (JetLimePaginatedColumn / JetLimePaginatedRow) with no extra dependency
 - Small, focused API with sensible defaults (JetLimeDefaults)
 
 ## 📦 Installation
@@ -125,6 +126,53 @@ JetLimeColumn(
   }
 }
 ```
+
+### 🔄 Paginated Timeline (Infinite Scroll)
+
+Use [JetLimePaginatedColumn](https://pushpalroy.github.io/JetLime/jetlime/com.pushpal.jetlime/-jet-lime-paginated-column.html)
+(or `JetLimePaginatedRow`) to load items page by page as the user scrolls. The component watches the
+scroll position and calls `onLoadMore` when the user gets within `loadMoreThreshold` items of the end,
+as long as a page is not already loading and more items remain. Pagination is implemented natively —
+no extra dependency is added.
+
+You own the page state (`itemsList`, `isLoading`, `hasMoreItems`); append the next page inside
+`onLoadMore` and update the flags. While `hasMoreItems` is `true`, the timeline line stays continuous
+into the next page, and it terminates once you set `hasMoreItems = false`.
+
+```kotlin
+val items = remember { mutableStateListOf<Item>() }
+var isLoading by remember { mutableStateOf(false) }
+var hasMore by remember { mutableStateOf(true) }
+val scope = rememberCoroutineScope()
+
+// Trigger the first page; the scroll-based loader fires only once items exist.
+LaunchedEffect(Unit) { if (items.isEmpty()) loadNextPage() }
+
+JetLimePaginatedColumn(
+  itemsList = ItemsList(items),
+  key = { _, item -> item.id },
+  isLoading = isLoading,
+  hasMoreItems = hasMore,
+  onLoadMore = {
+    scope.launch {
+      isLoading = true
+      val page = repository.loadNextPage() // your data source
+      items.addAll(page.items)
+      hasMore = !page.isLast
+      isLoading = false
+    }
+  },
+) { index, item, position ->
+  JetLimeEvent(
+    style = JetLimeEventDefaults.eventStyle(position = position)
+  ) {
+    // Content here
+  }
+}
+```
+
+A default centered progress indicator is shown while `isLoading` is `true`; override it with the
+`loadingContent` parameter.
 
 ### 🎛️ Customize `JetLimeColumn` Style
 

--- a/jetlime/src/androidTest/java/com/pushpal/jetlime/JetLimePaginatedColumnTest.kt
+++ b/jetlime/src/androidTest/java/com/pushpal/jetlime/JetLimePaginatedColumnTest.kt
@@ -232,6 +232,34 @@ class JetLimePaginatedColumnTest {
   }
 
   @Test
+  fun jetLimePaginatedColumn_singleItemStaysStartWhileMoreItems() {
+    val itemsList = ItemsList(persistentListOf("Item 1"))
+    var isNotStart: Boolean? = null
+    var isNotEnd: Boolean? = null
+
+    composeTestRule.setContent {
+      JetLimePaginatedColumn(
+        itemsList = itemsList,
+        onLoadMore = {},
+        hasMoreItems = true,
+        itemContent = { _, item, position ->
+          isNotStart = position.isNotStart()
+          isNotEnd = position.isNotEnd()
+          JetLimeEvent {
+            Text(text = item)
+          }
+        },
+      )
+    }
+
+    composeTestRule.waitForIdle()
+    // The single item is still the timeline start: only the outgoing connector is forced on,
+    // so no incoming connector is drawn before the first event.
+    assertThat(isNotStart).isFalse()
+    assertThat(isNotEnd).isTrue()
+  }
+
+  @Test
   fun jetLimePaginatedColumn_lastItemTerminatesOnLastPage() {
     val itemsList = ItemsList(persistentListOf("Item 1", "Item 2", "Item 3"))
     val isNotEndByIndex = mutableMapOf<Int, Boolean>()

--- a/jetlime/src/androidTest/java/com/pushpal/jetlime/JetLimePaginatedColumnTest.kt
+++ b/jetlime/src/androidTest/java/com/pushpal/jetlime/JetLimePaginatedColumnTest.kt
@@ -1,0 +1,207 @@
+/*
+* MIT License
+*
+* Copyright (c) 2024 Pushpal Roy
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+*/
+package com.pushpal.jetlime
+
+import android.annotation.SuppressLint
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollToNode
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import kotlinx.collections.immutable.persistentListOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@SuppressLint("ComposableNaming")
+@RunWith(AndroidJUnit4::class)
+class JetLimePaginatedColumnTest {
+
+  @get:Rule
+  val composeTestRule = createComposeRule()
+
+  @Test
+  fun jetLimePaginatedColumn_displaysItems() {
+    val itemsList = ItemsList(persistentListOf("Item 1", "Item 2"))
+
+    composeTestRule.setContent {
+      JetLimePaginatedColumn(
+        itemsList = itemsList,
+        onLoadMore = {},
+        itemContent = { _, item, _ ->
+          JetLimeEvent {
+            Text(text = item)
+          }
+        },
+      )
+    }
+
+    composeTestRule.onNodeWithText("Item 1").assertIsDisplayed()
+    composeTestRule.onNodeWithText("Item 2").assertIsDisplayed()
+  }
+
+  @Test
+  fun jetLimePaginatedColumn_showsLoadingContentWhenLoading() {
+    val itemsList = ItemsList(persistentListOf("Item 1", "Item 2"))
+
+    composeTestRule.setContent {
+      JetLimePaginatedColumn(
+        itemsList = itemsList,
+        onLoadMore = {},
+        isLoading = true,
+        loadingContent = {
+          Text(text = "Loading", modifier = Modifier.testTag("LoadingFooter"))
+        },
+        itemContent = { _, item, _ ->
+          JetLimeEvent {
+            Text(text = item)
+          }
+        },
+      )
+    }
+
+    composeTestRule.onNodeWithTag("LoadingFooter").assertIsDisplayed()
+  }
+
+  @Test
+  fun jetLimePaginatedColumn_triggersLoadMoreOnScroll() {
+    val items = mutableStateListOf<String>().apply {
+      addAll((1..30).map { "Item $it" })
+    }
+    var loadMoreCount = 0
+
+    composeTestRule.setContent {
+      JetLimePaginatedColumn(
+        modifier = Modifier.testTag("JetLimePaginatedColumn"),
+        itemsList = ItemsList(items),
+        key = { _, item -> item },
+        onLoadMore = {
+          loadMoreCount++
+          val next = items.size
+          items.addAll((next + 1..next + 10).map { "Item $it" })
+        },
+        itemContent = { _, item, _ ->
+          JetLimeEvent {
+            Text(text = item)
+          }
+        },
+      )
+    }
+
+    composeTestRule.onNodeWithTag("JetLimePaginatedColumn")
+      .performScrollToNode(hasText("Item 29"))
+    composeTestRule.waitForIdle()
+
+    assertThat(loadMoreCount).isAtLeast(1)
+    // A subsequent page should have been appended and become reachable.
+    composeTestRule.onNodeWithTag("JetLimePaginatedColumn")
+      .performScrollToNode(hasText("Item 31"))
+    composeTestRule.onNodeWithText("Item 31").assertIsDisplayed()
+  }
+
+  @Test
+  fun jetLimePaginatedColumn_doesNotLoadMoreWhenNoMoreItems() {
+    val items = mutableStateListOf<String>().apply {
+      addAll((1..30).map { "Item $it" })
+    }
+    var loadMoreCount = 0
+
+    composeTestRule.setContent {
+      JetLimePaginatedColumn(
+        modifier = Modifier.testTag("JetLimePaginatedColumn"),
+        itemsList = ItemsList(items),
+        key = { _, item -> item },
+        hasMoreItems = false,
+        onLoadMore = { loadMoreCount++ },
+        itemContent = { _, item, _ ->
+          JetLimeEvent {
+            Text(text = item)
+          }
+        },
+      )
+    }
+
+    composeTestRule.onNodeWithTag("JetLimePaginatedColumn")
+      .performScrollToNode(hasText("Item 30"))
+    composeTestRule.waitForIdle()
+
+    assertThat(loadMoreCount).isEqualTo(0)
+  }
+
+  @Test
+  fun jetLimePaginatedColumn_lastItemConnectorContinuesWhileMoreItems() {
+    val itemsList = ItemsList(persistentListOf("Item 1", "Item 2", "Item 3"))
+    val isNotEndByIndex = mutableMapOf<Int, Boolean>()
+
+    composeTestRule.setContent {
+      JetLimePaginatedColumn(
+        itemsList = itemsList,
+        onLoadMore = {},
+        hasMoreItems = true,
+        itemContent = { index, item, position ->
+          isNotEndByIndex[index] = position.isNotEnd()
+          JetLimeEvent {
+            Text(text = item)
+          }
+        },
+      )
+    }
+
+    composeTestRule.waitForIdle()
+    // While more items can load, the last loaded item must keep drawing its connector.
+    assertThat(isNotEndByIndex[2]).isTrue()
+  }
+
+  @Test
+  fun jetLimePaginatedColumn_lastItemTerminatesOnLastPage() {
+    val itemsList = ItemsList(persistentListOf("Item 1", "Item 2", "Item 3"))
+    val isNotEndByIndex = mutableMapOf<Int, Boolean>()
+
+    composeTestRule.setContent {
+      JetLimePaginatedColumn(
+        itemsList = itemsList,
+        onLoadMore = {},
+        hasMoreItems = false,
+        itemContent = { index, item, position ->
+          isNotEndByIndex[index] = position.isNotEnd()
+          JetLimeEvent {
+            Text(text = item)
+          }
+        },
+      )
+    }
+
+    composeTestRule.waitForIdle()
+    // On the last page, the last item is the timeline end and its connector terminates.
+    assertThat(isNotEndByIndex[2]).isFalse()
+  }
+}

--- a/jetlime/src/androidTest/java/com/pushpal/jetlime/JetLimePaginatedColumnTest.kt
+++ b/jetlime/src/androidTest/java/com/pushpal/jetlime/JetLimePaginatedColumnTest.kt
@@ -29,6 +29,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -90,6 +92,54 @@ class JetLimePaginatedColumnTest {
     }
 
     composeTestRule.onNodeWithTag("LoadingFooter").assertIsDisplayed()
+  }
+
+  @Test
+  fun jetLimePaginatedColumn_showsDefaultLoaderWhenLoading() {
+    val itemsList = ItemsList(persistentListOf("Item 1", "Item 2"))
+
+    composeTestRule.setContent {
+      JetLimePaginatedColumn(
+        itemsList = itemsList,
+        onLoadMore = {},
+        isLoading = true,
+        itemContent = { _, item, _ ->
+          JetLimeEvent {
+            Text(text = item)
+          }
+        },
+      )
+    }
+
+    // The default footer is a circular progress indicator.
+    composeTestRule.onNode(
+      SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo),
+    ).assertIsDisplayed()
+  }
+
+  @Test
+  fun jetLimePaginatedColumn_hidesLoaderWhenLoadingContentIsNull() {
+    val itemsList = ItemsList(persistentListOf("Item 1", "Item 2"))
+
+    composeTestRule.setContent {
+      JetLimePaginatedColumn(
+        itemsList = itemsList,
+        onLoadMore = {},
+        isLoading = true,
+        loadingContent = null,
+        itemContent = { _, item, _ ->
+          JetLimeEvent {
+            Text(text = item)
+          }
+        },
+      )
+    }
+
+    // Items still render, but no footer loader is added at all.
+    composeTestRule.onNodeWithText("Item 1").assertIsDisplayed()
+    composeTestRule.onNode(
+      SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo),
+    ).assertDoesNotExist()
   }
 
   @Test

--- a/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/EventPosition.kt
+++ b/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/EventPosition.kt
@@ -57,6 +57,24 @@ class EventPosition internal constructor(val name: String) {
     fun dynamic(index: Int, listSize: Int) = eventPosition(index, listSize)
 
     /**
+     * Determines the event position for a paginated list, keeping the timeline line continuous
+     * while more pages can still be loaded.
+     *
+     * When [isLastPage] is `false`, the last currently-loaded item is treated as [MIDDLE] instead
+     * of [END] so its connector line keeps extending toward the loading indicator / next page,
+     * avoiding a flicker each time a new page is appended. Once [isLastPage] becomes `true`, the
+     * trailing item resolves to [END] and the line terminates correctly.
+     *
+     * @param index The index of the item in the list.
+     * @param listSize The total size of the currently-loaded list.
+     * @param isLastPage Whether the last page has been reached (no more items to load).
+     * @return [EventPosition] corresponding to the index, accounting for pending pages.
+     */
+    @Stable
+    internal fun dynamicPaginated(index: Int, listSize: Int, isLastPage: Boolean) =
+      if (!isLastPage && index == listSize - 1) MIDDLE else eventPosition(index, listSize)
+
+    /**
      * Internal function to determine the event position based on index and list size.
      */
     @Stable

--- a/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/EventPosition.kt
+++ b/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/EventPosition.kt
@@ -60,10 +60,12 @@ class EventPosition internal constructor(val name: String) {
      * Determines the event position for a paginated list, keeping the timeline line continuous
      * while more pages can still be loaded.
      *
-     * When [isLastPage] is `false`, the last currently-loaded item is treated as [MIDDLE] instead
-     * of [END] so its connector line keeps extending toward the loading indicator / next page,
-     * avoiding a flicker each time a new page is appended. Once [isLastPage] becomes `true`, the
-     * trailing item resolves to [END] and the line terminates correctly.
+     * When [isLastPage] is `false`, the last currently-loaded item only forces its outgoing
+     * connector on so the line keeps extending toward the loading indicator / next page, avoiding a
+     * flicker each time a new page is appended. For a trailing item that is not also the first item
+     * this means [MIDDLE]; a single loaded item (index 0) stays [START] so no incoming connector is
+     * drawn before the first event. Once [isLastPage] becomes `true`, the trailing item resolves to
+     * [END] and the line terminates correctly.
      *
      * @param index The index of the item in the list.
      * @param listSize The total size of the currently-loaded list.
@@ -72,7 +74,11 @@ class EventPosition internal constructor(val name: String) {
      */
     @Stable
     internal fun dynamicPaginated(index: Int, listSize: Int, isLastPage: Boolean) =
-      if (!isLastPage && index == listSize - 1) MIDDLE else eventPosition(index, listSize)
+      if (!isLastPage && index == listSize - 1) {
+        if (index == 0) START else MIDDLE
+      } else {
+        eventPosition(index, listSize)
+      }
 
     /**
      * Internal function to determine the event position based on index and list size.

--- a/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/JetLimeDefaults.kt
+++ b/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/JetLimeDefaults.kt
@@ -53,6 +53,12 @@ object JetLimeDefaults {
   private val ItemSpacing: Dp = 8.dp
 
   /**
+   * The default number of items from the end of the list at which [JetLimePaginatedColumn] or
+   * [JetLimePaginatedRow] triggers the `onLoadMore` callback to fetch the next page.
+   */
+  val LoadMoreThreshold: Int = 3
+
+  /**
    * Creates a linear gradient brush for lines in [JetLimeColumn] or [JetLimeRow] components.
    *
    * @param colors The colors to be used in the gradient. Defaults to primary, secondary, and tertiary colors from MaterialTheme's color scheme.

--- a/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/JetLimePaginatedList.kt
+++ b/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/JetLimePaginatedList.kt
@@ -1,0 +1,296 @@
+/*
+* MIT License
+*
+* Copyright (c) 2024 Pushpal Roy
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+*/
+package com.pushpal.jetlime
+
+import androidx.compose.foundation.gestures.ScrollableDefaults
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pushpal.jetlime.Arrangement.HORIZONTAL
+import com.pushpal.jetlime.Arrangement.VERTICAL
+
+/**
+ * A composable function that creates a vertical timeline with built-in pagination (infinite scroll).
+ *
+ * It behaves exactly like [JetLimeColumn] but additionally invokes [onLoadMore] when the user scrolls
+ * within [loadMoreThreshold] items of the end, as long as [isLoading] is `false` and [hasMoreItems]
+ * is `true`. While a page is being fetched ([isLoading] is `true`), [loadingContent] is rendered as a
+ * footer. The page state ([itemsList], [isLoading], [hasMoreItems]) is owned by the caller — the
+ * caller appends the next page inside [onLoadMore] and flips the flags accordingly.
+ *
+ * The timeline's connecting line stays continuous across page boundaries: while [hasMoreItems] is
+ * `true` the last loaded item keeps drawing its connector toward the next page instead of terminating.
+ *
+ * Example usage:
+ *
+ * ```
+ *  val items = remember { mutableStateListOf<MyItem>() }
+ *  var isLoading by remember { mutableStateOf(false) }
+ *  var hasMore by remember { mutableStateOf(true) }
+ *  val scope = rememberCoroutineScope()
+ *
+ *  JetLimePaginatedColumn(
+ *    itemsList = ItemsList(items),
+ *    isLoading = isLoading,
+ *    hasMoreItems = hasMore,
+ *    key = { _, item -> item.id },
+ *    onLoadMore = {
+ *      scope.launch {
+ *        isLoading = true
+ *        val page = repository.loadNextPage()
+ *        items.addAll(page.items)
+ *        hasMore = !page.isLast
+ *        isLoading = false
+ *      }
+ *    },
+ *  ) { _, item, position ->
+ *    JetLimeEvent(style = JetLimeEventDefaults.eventStyle(position = position)) {
+ *      ComposableContent(item = item)
+ *    }
+ *  }
+ * ```
+ *
+ * @param T The type of items in the items list.
+ * @param itemsList A list of items currently loaded in the timeline.
+ * @param onLoadMore Callback invoked when the next page should be loaded.
+ * @param modifier A modifier to be applied to the LazyColumn.
+ * @param style The JetLime style configuration. Defaults to a predefined column style.
+ * @param listState The state object to be used for the LazyColumn.
+ * @param contentPadding The padding to apply to the content inside the LazyColumn.
+ * @param key A factory of stable and unique keys representing the item. If null is passed the position in the list will represent the key.
+ * @param isLoading Whether a page fetch is currently in flight. Suppresses further [onLoadMore] calls and shows [loadingContent].
+ * @param hasMoreItems Whether more pages can be loaded. When `false`, [onLoadMore] is not called and the timeline line terminates at the last item.
+ * @param loadMoreThreshold The number of items from the end at which [onLoadMore] is triggered.
+ * @param loadingContent The footer composable shown while [isLoading] is `true`.
+ * @param itemContent A composable lambda that takes an index, an item of type [T], and an [EventPosition] to build each item's content.
+ */
+@Composable
+fun <T> JetLimePaginatedColumn(
+  itemsList: ItemsList<T>,
+  onLoadMore: () -> Unit,
+  modifier: Modifier = Modifier,
+  style: JetLimeStyle = JetLimeDefaults.columnStyle(),
+  listState: LazyListState = rememberLazyListState(),
+  contentPadding: PaddingValues = PaddingValues(0.dp),
+  key: ((index: Int, item: T) -> Any)? = null,
+  isLoading: Boolean = false,
+  hasMoreItems: Boolean = true,
+  loadMoreThreshold: Int = JetLimeDefaults.LoadMoreThreshold,
+  loadingContent: @Composable () -> Unit = { DefaultColumnLoadingContent() },
+  itemContent: @Composable (index: Int, T, EventPosition) -> Unit,
+) {
+  TriggerLoadMore(
+    listState = listState,
+    loadMoreThreshold = loadMoreThreshold,
+    isLoading = isLoading,
+    hasMoreItems = hasMoreItems,
+    onLoadMore = onLoadMore,
+  )
+
+  val providedStyle = remember(style) { style.alignment(VERTICAL) }
+  CompositionLocalProvider(LocalJetLimeStyle provides providedStyle) {
+    LazyColumn(
+      modifier = modifier,
+      state = listState,
+      reverseLayout = false,
+      verticalArrangement = Arrangement.Top,
+      horizontalAlignment = Alignment.Start,
+      flingBehavior = ScrollableDefaults.flingBehavior(),
+      userScrollEnabled = true,
+      contentPadding = contentPadding,
+    ) {
+      itemsIndexed(
+        items = itemsList.items,
+        key = key,
+      ) { index, item ->
+        val eventPosition = EventPosition.dynamicPaginated(
+          index = index,
+          listSize = itemsList.items.size,
+          isLastPage = !hasMoreItems,
+        )
+        itemContent(index, item, eventPosition)
+      }
+      if (isLoading) {
+        item(key = LoadMoreItemKey) { loadingContent() }
+      }
+    }
+  }
+}
+
+/**
+ * A composable function that creates a horizontal timeline with built-in pagination (infinite scroll).
+ *
+ * It behaves exactly like [JetLimeRow] but additionally invokes [onLoadMore] when the user scrolls
+ * within [loadMoreThreshold] items of the end, as long as [isLoading] is `false` and [hasMoreItems]
+ * is `true`. While a page is being fetched ([isLoading] is `true`), [loadingContent] is rendered as a
+ * trailing item. The page state ([itemsList], [isLoading], [hasMoreItems]) is owned by the caller.
+ *
+ * The timeline's connecting line stays continuous across page boundaries: while [hasMoreItems] is
+ * `true` the last loaded item keeps drawing its connector toward the next page instead of terminating.
+ *
+ * @param T The type of items in the items list.
+ * @param itemsList A list of items currently loaded in the timeline.
+ * @param onLoadMore Callback invoked when the next page should be loaded.
+ * @param modifier A modifier to be applied to the LazyRow.
+ * @param style The JetLime style configuration. Defaults to a predefined row style.
+ * @param listState The state object to be used for the LazyRow.
+ * @param contentPadding The padding to apply to the content inside the LazyRow.
+ * @param key A factory of stable and unique keys representing the item. If null is passed the position in the list will represent the key.
+ * @param isLoading Whether a page fetch is currently in flight. Suppresses further [onLoadMore] calls and shows [loadingContent].
+ * @param hasMoreItems Whether more pages can be loaded. When `false`, [onLoadMore] is not called and the timeline line terminates at the last item.
+ * @param loadMoreThreshold The number of items from the end at which [onLoadMore] is triggered.
+ * @param loadingContent The trailing composable shown while [isLoading] is `true`.
+ * @param itemContent A composable lambda that takes an index, an item of type [T], and an [EventPosition] to build each item's content.
+ */
+@Composable
+fun <T> JetLimePaginatedRow(
+  itemsList: ItemsList<T>,
+  onLoadMore: () -> Unit,
+  modifier: Modifier = Modifier,
+  style: JetLimeStyle = JetLimeDefaults.rowStyle(),
+  listState: LazyListState = rememberLazyListState(),
+  contentPadding: PaddingValues = PaddingValues(0.dp),
+  key: ((index: Int, item: T) -> Any)? = null,
+  isLoading: Boolean = false,
+  hasMoreItems: Boolean = true,
+  loadMoreThreshold: Int = JetLimeDefaults.LoadMoreThreshold,
+  loadingContent: @Composable () -> Unit = { DefaultRowLoadingContent() },
+  itemContent: @Composable (index: Int, T, EventPosition) -> Unit,
+) {
+  TriggerLoadMore(
+    listState = listState,
+    loadMoreThreshold = loadMoreThreshold,
+    isLoading = isLoading,
+    hasMoreItems = hasMoreItems,
+    onLoadMore = onLoadMore,
+  )
+
+  val providedStyle = remember(style) { style.alignment(HORIZONTAL) }
+  CompositionLocalProvider(LocalJetLimeStyle provides providedStyle) {
+    LazyRow(
+      modifier = modifier,
+      state = listState,
+      reverseLayout = false,
+      horizontalArrangement = Arrangement.Start,
+      verticalAlignment = Alignment.Top,
+      flingBehavior = ScrollableDefaults.flingBehavior(),
+      userScrollEnabled = true,
+      contentPadding = contentPadding,
+    ) {
+      itemsIndexed(
+        items = itemsList.items,
+        key = key,
+      ) { index, item ->
+        val eventPosition = EventPosition.dynamicPaginated(
+          index = index,
+          listSize = itemsList.items.size,
+          isLastPage = !hasMoreItems,
+        )
+        itemContent(index, item, eventPosition)
+      }
+      if (isLoading) {
+        item(key = LoadMoreItemKey) { loadingContent() }
+      }
+    }
+  }
+}
+
+/** Stable key for the load-more footer/trailing item. */
+private val LoadMoreItemKey = "jetlime-load-more"
+
+/**
+ * Observes [listState] and invokes [onLoadMore] once the user scrolls within [loadMoreThreshold]
+ * items of the end, guarded by [isLoading] and [hasMoreItems].
+ */
+@Composable
+private fun TriggerLoadMore(
+  listState: LazyListState,
+  loadMoreThreshold: Int,
+  isLoading: Boolean,
+  hasMoreItems: Boolean,
+  onLoadMore: () -> Unit,
+) {
+  val currentOnLoadMore by rememberUpdatedState(onLoadMore)
+  val shouldLoadMore by remember(listState, loadMoreThreshold) {
+    derivedStateOf {
+      val layoutInfo = listState.layoutInfo
+      val totalItems = layoutInfo.totalItemsCount
+      val lastVisibleIndex =
+        layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: return@derivedStateOf false
+      totalItems > 0 && lastVisibleIndex >= totalItems - 1 - loadMoreThreshold
+    }
+  }
+
+  LaunchedEffect(shouldLoadMore, isLoading, hasMoreItems) {
+    if (shouldLoadMore && !isLoading && hasMoreItems) {
+      currentOnLoadMore()
+    }
+  }
+}
+
+/** Default centered progress indicator used as the footer of [JetLimePaginatedColumn]. */
+@Composable
+private fun DefaultColumnLoadingContent() {
+  Box(
+    modifier = Modifier
+      .fillMaxWidth()
+      .padding(16.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    CircularProgressIndicator()
+  }
+}
+
+/** Default centered progress indicator used as the trailing item of [JetLimePaginatedRow]. */
+@Composable
+private fun DefaultRowLoadingContent() {
+  Box(
+    modifier = Modifier
+      .fillMaxHeight()
+      .padding(16.dp),
+    contentAlignment = Alignment.Center,
+  ) {
+    CircularProgressIndicator()
+  }
+}

--- a/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/JetLimePaginatedList.kt
+++ b/jetlime/src/commonMain/kotlin/com/pushpal/jetlime/JetLimePaginatedList.kt
@@ -102,7 +102,7 @@ import com.pushpal.jetlime.Arrangement.VERTICAL
  * @param isLoading Whether a page fetch is currently in flight. Suppresses further [onLoadMore] calls and shows [loadingContent].
  * @param hasMoreItems Whether more pages can be loaded. When `false`, [onLoadMore] is not called and the timeline line terminates at the last item.
  * @param loadMoreThreshold The number of items from the end at which [onLoadMore] is triggered.
- * @param loadingContent The footer composable shown while [isLoading] is `true`.
+ * @param loadingContent The footer composable shown while [isLoading] is `true`. Defaults to a centered circular progress indicator; pass `null` to show no footer at all.
  * @param itemContent A composable lambda that takes an index, an item of type [T], and an [EventPosition] to build each item's content.
  */
 @Composable
@@ -117,7 +117,7 @@ fun <T> JetLimePaginatedColumn(
   isLoading: Boolean = false,
   hasMoreItems: Boolean = true,
   loadMoreThreshold: Int = JetLimeDefaults.LoadMoreThreshold,
-  loadingContent: @Composable () -> Unit = { DefaultColumnLoadingContent() },
+  loadingContent: (@Composable () -> Unit)? = { DefaultColumnLoadingContent() },
   itemContent: @Composable (index: Int, T, EventPosition) -> Unit,
 ) {
   TriggerLoadMore(
@@ -151,8 +151,9 @@ fun <T> JetLimePaginatedColumn(
         )
         itemContent(index, item, eventPosition)
       }
-      if (isLoading) {
-        item(key = LoadMoreItemKey) { loadingContent() }
+      val footer = loadingContent
+      if (isLoading && footer != null) {
+        item(key = LoadMoreItemKey) { footer() }
       }
     }
   }
@@ -180,7 +181,7 @@ fun <T> JetLimePaginatedColumn(
  * @param isLoading Whether a page fetch is currently in flight. Suppresses further [onLoadMore] calls and shows [loadingContent].
  * @param hasMoreItems Whether more pages can be loaded. When `false`, [onLoadMore] is not called and the timeline line terminates at the last item.
  * @param loadMoreThreshold The number of items from the end at which [onLoadMore] is triggered.
- * @param loadingContent The trailing composable shown while [isLoading] is `true`.
+ * @param loadingContent The trailing composable shown while [isLoading] is `true`. Defaults to a centered circular progress indicator; pass `null` to show no trailing loader at all.
  * @param itemContent A composable lambda that takes an index, an item of type [T], and an [EventPosition] to build each item's content.
  */
 @Composable
@@ -195,7 +196,7 @@ fun <T> JetLimePaginatedRow(
   isLoading: Boolean = false,
   hasMoreItems: Boolean = true,
   loadMoreThreshold: Int = JetLimeDefaults.LoadMoreThreshold,
-  loadingContent: @Composable () -> Unit = { DefaultRowLoadingContent() },
+  loadingContent: (@Composable () -> Unit)? = { DefaultRowLoadingContent() },
   itemContent: @Composable (index: Int, T, EventPosition) -> Unit,
 ) {
   TriggerLoadMore(
@@ -229,8 +230,9 @@ fun <T> JetLimePaginatedRow(
         )
         itemContent(index, item, eventPosition)
       }
-      if (isLoading) {
-        item(key = LoadMoreItemKey) { loadingContent() }
+      val footer = loadingContent
+      if (isLoading && footer != null) {
+        item(key = LoadMoreItemKey) { footer() }
       }
     }
   }

--- a/sample/composeApp/src/commonMain/kotlin/Home.kt
+++ b/sample/composeApp/src/commonMain/kotlin/Home.kt
@@ -54,6 +54,7 @@ import timelines.BasicVerticalTimeLine
 import timelines.CustomizedHorizontalTimeLine
 import timelines.CustomizedVerticalTimeLine
 import timelines.ExtendedVerticalTimeLine
+import timelines.PaginatedVerticalTimeLine
 import timelines.VerticalDynamicTimeLine
 
 @Composable
@@ -82,7 +83,7 @@ fun HomeScreen(
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun HomeContent(modifier: Modifier = Modifier) {
-  val tabs = remember { listOf("Basic", "Dashed", "Dynamic", "Custom", "Extended") }
+  val tabs = remember { listOf("Basic", "Dashed", "Dynamic", "Custom", "Extended", "Paginated") }
   var selectedIndex by remember { mutableIntStateOf(0) }
   val snackBarState = remember { SnackbarHostState() }
   val coroutineScope = rememberCoroutineScope()
@@ -132,6 +133,10 @@ fun HomeContent(modifier: Modifier = Modifier) {
           }
 
           4 -> ExtendedVerticalTimeLine { coroutineScope.launch { snackBarState.showSnackbar(it) } }
+
+          5 -> PaginatedVerticalTimeLine {
+            coroutineScope.launch { snackBarState.showSnackbar(it) }
+          }
         }
       }
     }

--- a/sample/composeApp/src/commonMain/kotlin/timelines/PaginatedVerticalTimeLine.kt
+++ b/sample/composeApp/src/commonMain/kotlin/timelines/PaginatedVerticalTimeLine.kt
@@ -1,0 +1,130 @@
+/*
+* MIT License
+*
+* Copyright (c) 2024 Pushpal Roy
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+* SOFTWARE.
+*
+*/
+package timelines
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.pushpal.jetlime.ItemsList
+import com.pushpal.jetlime.JetLimeDefaults
+import com.pushpal.jetlime.JetLimeEvent
+import com.pushpal.jetlime.JetLimeEventDefaults
+import com.pushpal.jetlime.JetLimePaginatedColumn
+import data.Item
+import data.getCharacters
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import timelines.event.VerticalEventContent
+
+private const val PAGE_SIZE = 6
+
+@Composable
+fun PaginatedVerticalTimeLine(
+  modifier: Modifier = Modifier,
+  showSnackbar: (message: String) -> Unit,
+) {
+  val listState = rememberLazyListState()
+  val coroutineScope = rememberCoroutineScope()
+  val allCharacters = remember { getCharacters().distinct() }
+
+  val items = remember { mutableStateListOf<Item>() }
+  var page by remember { mutableIntStateOf(0) }
+  var isLoading by remember { mutableStateOf(false) }
+  var hasMoreItems by remember { mutableStateOf(true) }
+
+  val loadPage: () -> Unit = {
+    coroutineScope.launch {
+      isLoading = true
+      // Simulate a network/database fetch.
+      delay(800)
+      val start = page * PAGE_SIZE
+      val nextChunk = allCharacters.drop(start).take(PAGE_SIZE)
+      items.addAll(nextChunk)
+      page += 1
+      hasMoreItems = items.size < allCharacters.size
+      isLoading = false
+    }
+  }
+
+  // The first page must be triggered explicitly; the scroll-based loader only fires once items exist.
+  LaunchedEffect(Unit) {
+    if (items.isEmpty()) loadPage()
+  }
+
+  Scaffold(
+    modifier = modifier,
+    contentWindowInsets = WindowInsets(0.dp),
+  ) { paddingValues ->
+    Surface(
+      modifier = Modifier
+        .padding(paddingValues)
+        .fillMaxSize(),
+    ) {
+      JetLimePaginatedColumn(
+        modifier = Modifier.padding(32.dp),
+        itemsList = ItemsList(items),
+        listState = listState,
+        style = JetLimeDefaults.columnStyle(
+          lineBrush = JetLimeDefaults.lineGradientBrush(),
+        ),
+        key = { _, item -> item.id },
+        isLoading = isLoading,
+        hasMoreItems = hasMoreItems,
+        onLoadMore = loadPage,
+      ) { index, item, position ->
+        JetLimeEvent(
+          modifier = Modifier.clickable {
+            showSnackbar("Clicked on item: $index")
+          },
+          style = JetLimeEventDefaults.eventStyle(position = position),
+        ) {
+          VerticalEventContent(item = item)
+        }
+      }
+    }
+  }
+}
+
+@Preview
+@Composable
+private fun PreviewPaginatedVerticalTimeLine() {
+  PaginatedVerticalTimeLine {}
+}


### PR DESCRIPTION
## Context

Resolves [discussion #64](https://github.com/pushpalroy/JetLime/discussions/64) — a request for JetLime to manage pagination / infinite scroll internally so consumers don't have to wire up scroll detection themselves.

Implemented **natively in Compose — no new dependency** (JetLime stays dependency-light).

## What's added

Two new, purely additive composables — `JetLimePaginatedColumn` and `JetLimePaginatedRow`:

- Watch `LazyListState.layoutInfo` via `derivedStateOf` and fire `onLoadMore` when the user scrolls within `loadMoreThreshold` items of the end — guarded by `!isLoading && hasMoreItems`.
- Render an optional `loadingContent` footer while `isLoading` (default: centered `CircularProgressIndicator`).
- `onLoadMore` wrapped in `rememberUpdatedState` so the restarting effect always calls the latest lambda.
- Page state (`itemsList`, `isLoading`, `hasMoreItems`) is owned by the caller.

The existing `JetLimeColumn` / `JetLimeRow` signatures are **untouched** → fully backward compatible.

### Timeline-line continuity

`EventPosition.dynamicPaginated(index, listSize, isLastPage)` keeps the last loaded item as `MIDDLE` (not `END`) while more pages can load, so the connecting line flows continuously into the next page instead of flickering on each append. It resolves to `END` once `hasMoreItems = false`.

## Changes

- **`JetLimePaginatedList.kt`** (new) — the two composables + load-more trigger.
- **`EventPosition.kt`** — `dynamicPaginated()` factory.
- **`JetLimeDefaults.kt`** — `LoadMoreThreshold` (default `3`).
- **Sample** — new "Paginated" tab + `PaginatedVerticalTimeLine` screen (fake paged data source).
- **README** — Pagination section + highlight.
- **Tests** — `JetLimePaginatedColumnTest`: display, loading footer, scroll trigger, `hasMoreItems` guard, and the connector-continuity logic.

> Note: the first page must be triggered explicitly by the consumer — the scroll-based loader only fires once items exist. This is documented in the README and demonstrated in the sample.

## Verification

- ✅ `spotlessCheck` passes
- ✅ `:jetlime` compiles for Android, Desktop, and common metadata
- ✅ `:sample:composeApp` compiles
- ⚠️ Instrumented tests compile, install, and run, but the suite currently can't pass on Android API 37 (beta) due to a pre-existing `androidx.test`/`InputManager.getInstance` incompatibility that affects all instrumented tests (not specific to this change). They should be run on a stable API (≤ 36) device/emulator.