### PR TITLE
chore: upgrade dependencies to latest stable & fix build deprecations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ subprojects {
         )
         .customRuleSets(
           listOf(
-            "io.nlopez.compose.rules:ktlint:0.3.11",
+            "io.nlopez.compose.rules:ktlint:0.6.1",
           ),
         )
       licenseHeaderFile(rootProject.file("spotless/copyright.kt"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,6 @@ kotlin.incremental.js=true
 kotlin.incremental.wasm=true
 # KMP
 kotlin.mpp.enableCInteropCommonization=true
-kotlin.mpp.androidSourceSetLayoutVersion=2
 org.jetbrains.compose.experimental.jscanvas.enabled=true
 # Before publishing to central the library should be tested in local:
 # ./gradlew publishToMavenLocal. This will generate sources for our source sets

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,17 +1,17 @@
 [versions]
-kotlin = "2.3.20"
+kotlin = "2.4.0"
 agp = "8.13.1"
 activityCompose = "1.13.0"
 compose-plugin = "1.10.3"
-kotlinxCollectionsImmutable = "0.4.0"
+kotlinxCollectionsImmutable = "0.5.0"
 truth = "1.4.5"
 vanniktech = "0.36.0"
 dokka = "2.2.0"
-spotless = "8.4.0"
+spotless = "8.6.0"
 report = "1.5.0"
 junitVersion = "1.3.0"
 androidxTest = "1.7.0"
-composeBom = "2026.04.00"
+composeBom = "2026.05.01"
 
 [libraries]
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "junitVersion" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 #Thu Feb 29 20:52:44 CST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/jetlime/build.gradle.kts
+++ b/jetlime/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
     }
   }
 
-  js(IR) {
+  js {
     browser()
     binaries.library()
   }
@@ -74,6 +74,7 @@ kotlin {
       implementation(compose.material3)
       implementation(compose.ui)
       implementation(compose.components.uiToolingPreview)
+      implementation(compose.preview)
       api(libs.kotlinx.collections.immutable)
     }
     desktopMain.dependencies {

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -2917,7 +2917,16 @@ streamroller@^3.1.5:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2949,7 +2958,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3305,7 +3321,16 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 kotlin {
-  js(IR) {
+  js {
     browser()
     binaries.executable()
   }
@@ -27,11 +27,8 @@ kotlin {
         outputFileName = "composeApp.js"
         devServer =
           (devServer ?: KotlinWebpackConfig.DevServer()).apply {
-            static =
-              (static ?: mutableListOf()).apply {
-                // Serve sources to debug inside browser
-                add(project.projectDir.path)
-              }
+            // Serve sources to debug inside browser
+            static(project.projectDir.path)
           }
       }
     }
@@ -85,6 +82,7 @@ kotlin {
       implementation(compose.components.resources)
       implementation(compose.materialIconsExtended)
       implementation(compose.components.uiToolingPreview)
+      implementation(compose.preview)
 
       // Local library
       implementation(project(":jetlime"))

--- a/sample/composeApp/src/commonMain/kotlin/Home.kt
+++ b/sample/composeApp/src/commonMain/kotlin/Home.kt
@@ -147,8 +147,8 @@ fun HomeContent(modifier: Modifier = Modifier) {
 @Composable
 fun HomeAppBar(
   isDarkTheme: Boolean,
-  modifier: Modifier = Modifier,
   onThemeChange: ((Boolean) -> Unit)?,
+  modifier: Modifier = Modifier,
 ) {
   TopAppBar(
     title = {
@@ -167,7 +167,7 @@ fun HomeAppBar(
   )
 }
 
-@Preview
+@androidx.compose.ui.tooling.preview.Preview
 @Composable
 private fun PreviewHomeScreen() {
   HomeScreen()


### PR DESCRIPTION
## Summary

Upgrades libraries/tools to latest stable and clears build-file deprecations. Verified compiling on **all targets — Android, Desktop (JVM), JS, WASM, and iOS (x64/arm64/sim)** — and `spotlessCheck` passes.

## Upgrades
| | from | to |
|---|---|---|
| Gradle | 9.4.1 | **9.5.1** |
| Kotlin | 2.3.20 | **2.4.0** |
| Compose BOM | 2026.04.00 | **2026.05.01** |
| kotlinx-collections-immutable | 0.4.0 | **0.5.0** |
| Spotless | 8.4.0 | **8.6.0** |
| compose ktlint rules | 0.3.11 | **0.6.1** |

(activity-compose, vanniktech, dokka, report-gen, test-runner, ext:junit, truth, junit4 were already latest.)

## Deprecation fixes (build files)
- `js(IR)` → `js` in both modules (IR is the only JS backend now).
- Removed deprecated `kotlin.mpp.androidSourceSetLayoutVersion` property.
- Webpack `DevServer.static` property → `static()` function (sample).
- Reordered `HomeAppBar` params so the required event lambda isn't trailing (new compose ktlint rule).

## Preview tooling
- Added `compose.preview` (`org.jetbrains.compose.ui:ui-tooling-preview`) to `commonMain` so `androidx.compose.ui.tooling.preview.Preview` resolves across all targets (incl. wasmJs/js) at Compose 1.10.3.

## Held back deliberately
- **Compose Multiplatform stays 1.10.3** — 1.11.1's core artifacts (`runtime`/`foundation`/`ui`) don't publish iOS/native variants and break iOS resolution. (This also avoids the `compose.*` DSL deprecations, which only appear in 1.11.)
- **AGP stays 8.13.1** — AGP 9 has no clean KMP-application plugin for the sample module, so the only remaining warnings are the 2 AGP-internal `multi-string notation` deprecations (unfixable without AGP 9).

> Note: the source-level `@Preview` deprecation (`org.jetbrains…` → `androidx…`) is only fully multiplatform on Compose 1.11+, so it remains until CMP ships an iOS-complete 1.11+.