### PR TITLE
chore: bump version to 4.4.0 & refresh version docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ JetLime is a Kotlin Multiplatform (KMP) Compose Multiplatform library that rende
 The repo has two Gradle modules:
 - `:jetlime` — the library (all platform source in `src/commonMain/kotlin/com/pushpal/jetlime/`; Android-specific manifest + instrumented tests in `src/androidMain` and `src/androidTest`).
 - `:sample:composeApp` — a sample app that consumes `:jetlime` via `implementation(project(":jetlime"))` and runs on all five targets (Android, iOS via CocoaPods, Desktop, Web-JS, Web-WASM).
-JDK 17 is required for builds; CI uses JDK 21 only for the Spotless lint job. Kotlin 2.3.20, Compose Multiplatform 1.10.3, `androidTarget` compileSdk 36 / minSdk 23.
+JDK 17 is required for builds; CI uses JDK 21 only for the Spotless lint job. Kotlin 2.4.0, Compose Multiplatform 1.10.3, `androidTarget` compileSdk 36 / minSdk 23.
  
 ## Common Commands
  

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -78,7 +78,7 @@ The workflow updates all version references automatically. The files it touches 
 
 1. Go to **GitHub → Actions → Publish to Maven Central**
 2. Click **Run workflow**
-3. Enter the new version (e.g. `4.3.0`) and click **Run workflow**
+3. Enter the new version (e.g. `4.4.0`) and click **Run workflow**
 
 ### What the workflow does
 
@@ -89,7 +89,7 @@ The workflow updates all version references automatically. The files it touches 
 | Update versions | Runs `sed` across all version-bearing files |
 | Publish | Runs `publishAndReleaseToMavenCentral` — signs, uploads, and auto-releases |
 | Commit | Commits the version bump files and pushes to `main` |
-| Tag | Creates and pushes an annotated git tag (e.g. `4.3.0`) |
+| Tag | Creates and pushes an annotated git tag (e.g. `4.4.0`) |
 
 ### Step 3 — Verify
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > A simple yet highly customizable UI library to show a timeline view in Compose Multiplatform.
 
 [![Jetbrains Compose](https://img.shields.io/badge/Jetbrains%20Compose-1.10.3-blue?style=for-the-badge&logo=appveyor)](https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-compatibility-and-versioning.html#jetpack-compose-artifacts-used)
-![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-blue.svg?color=blue&style=for-the-badge)
+![Kotlin](https://img.shields.io/badge/Kotlin-2.4.0-blue.svg?color=blue&style=for-the-badge)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.pushpalroy/jetlime?style=for-the-badge&logo=appveyor)](https://search.maven.org/artifact/io.github.pushpalroy/jetlime)
 ![Stars](https://img.shields.io/github/stars/pushpalroy/jetlime?color=yellowgreen&style=for-the-badge)
 ![Forks](https://img.shields.io/github/forks/pushpalroy/jetlime?color=yellowgreen&style=for-the-badge)
@@ -43,7 +43,7 @@ In `build.gradle` of shared module, include the following dependency
 
 ```gradle
 dependencies {
-  implementation("io.github.pushpalroy:jetlime:4.3.0")
+  implementation("io.github.pushpalroy:jetlime:4.4.0")
 }
 ```
 

--- a/jetlime/build.gradle.kts
+++ b/jetlime/build.gradle.kts
@@ -23,7 +23,7 @@ dokka {
 
 kotlin {
   cocoapods {
-    version = "4.3.0"
+    version = "4.4.0"
     summary = "JetLime KMP Library"
     homepage = "https://github.com/pushpalroy/JetLime"
     ios.deploymentTarget = "14.0"
@@ -150,7 +150,7 @@ mavenPublishing {
   val artifactId = "jetlime"
 
   // Define coordinates for the published artifact
-  coordinates("io.github.pushpalroy", artifactId, "4.3.0")
+  coordinates("io.github.pushpalroy", artifactId, "4.4.0")
 
   // Configure POM metadata for the published artifact
   pom {

--- a/jetlime/jetlime.podspec
+++ b/jetlime/jetlime.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'jetlime'
-    spec.version                  = '4.3.0'
+    spec.version                  = '4.4.0'
     spec.homepage                 = 'https://github.com/pushpalroy/JetLime'
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/sample/composeApp/build.gradle.kts
+++ b/sample/composeApp/build.gradle.kts
@@ -88,7 +88,7 @@ kotlin {
       implementation(project(":jetlime"))
 
       // Uncomment for maven testing
-      // implementation("io.github.pushpalroy:jetlime:4.3.0")
+      // implementation("io.github.pushpalroy:jetlime:4.4.0")
     }
     desktopMain.dependencies {
       implementation(compose.desktop.currentOs)

--- a/scripts/add_git_tag.sh
+++ b/scripts/add_git_tag.sh
@@ -2,7 +2,7 @@
 
 # Script to add annotated tag with version number to the main branch
 # This script should be executed with the correct version number after every release to MavenCentral
-TAG="4.3.0"
+TAG="4.4.0"
 COMMENT="Release $TAG"
 BRANCH="main"
 


### PR DESCRIPTION
## Summary

Prepares the **4.4.0** release and refreshes version/dependency references in docs.

### Version bump (4.3.0 → 4.4.0)
- `jetlime/build.gradle.kts` — `coordinates(...)` + `cocoapods { version }`
- `jetlime/jetlime.podspec` — `spec.version`
- `scripts/add_git_tag.sh` — `TAG`
- `README.md` — install snippet
- `sample/composeApp/build.gradle.kts` — commented maven-test snippet

### Docs / dependency references
- `README.md` — Kotlin badge **2.3.20 → 2.4.0** (Compose badge stays **1.10.3**, which is what we ship)
- `PUBLISHING.md` — example version → 4.4.0
- `CLAUDE.md` — tech-stack line → Kotlin 2.4.0

No code changes; release metadata + docs only.